### PR TITLE
Feature speedtest

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,13 @@ skip_tags: true
 
 skip_commits:
   files:
-    - '*.md'
-    - '*.yml.default'
+    - "*.md"
+    - "*.yml.default"
   message: /\[minor\]/
 
 build_cloud: COMMUNITY
 
-image: 
+image:
   - Saltbox1804
 
 matrix:
@@ -21,112 +21,111 @@ max_jobs: 8
 
 environment:
   matrix:
+    - job_name: airdcpp
+    - job_name: airsonic
+    - job_name: alltube
+    - job_name: alternatrr
+    - job_name: alternatrrx
+    # - job_name: amongus
+    # - job_name: apprise
+    # - job_name: archivebox
+    - job_name: asshama
+    - job_name: autoscan
+    # - job_name: bazarrx
+    # - job_name: beets
+    # - job_name: bitwarden
+    # - job_name: booksonic
+    # - job_name: bookstack
+    - job_name: btrfsmaintenance
+    # - job_name: calibre
+    # - job_name: calibre-web
+    # - job_name: coder
+    # - job_name: comicstreamer
+    # - job_name: comixed
+    # - job_name: couchpotato
+    # - job_name: deemix
+    # - job_name: deemixrr
+    # - job_name: deezloader-remix
+    - job_name: deluge
+    # - job_name: delugevpn
+    # - job_name: emby2
+    # - job_name: embystat
+    - job_name: epms
+    # - job_name: filebot
+    # - job_name: filebrowser
+    # - job_name: filezilla
+    # - job_name: flaresolverr
+    # - job_name: funkwhale
+    # - job_name: gazee
+    # - job_name: glances
+    # - job_name: goplaxt
+    # - job_name: gotify
+    - job_name: grafana
+    # - job_name: handbrake
+    # - job_name: healthchecks
+    # - job_name: heimdall
+    - job_name: influxdb
+    # - job_name: invoiceninja
+    # - job_name: jdownloader2
+    # - job_name: jellyfin
+    # - job_name: jirafeau
+    # - job_name: kitana
+    # - job_name: komga
+    # - job_name: lazylibrarian
+    # - job_name: lidarrx
+    # - job_name: logarr
+    # - job_name: mediabutler
+    # - job_name: medusa
+    # - job_name: minecraft
+    # - job_name: monitorr
+    # - job_name: mylar3
+    # - job_name: navidrome
+    # - job_name: nextcloud
+    # - job_name: nowshowing
+    # - job_name: nzbhydra
+    - job_name: ombi
+    - job_name: ombix
+    # - job_name: organizrv1
+    # - job_name: ouroboros
+    - job_name: overseerr
+    # - job_name: petio
+    # - job_name: plex2
+    - job_name: prowlarr
+    # - job_name: pyload
+    - job_name: qbittorrent
+    # - job_name: qbittorrentvpn
+    # - job_name: quassel
+    - job_name: radarrx
+    - job_name: redbot
+    # - job_name: requestrr
+    # - job_name: requestrrx
+    # - job_name: resilio-sync
+    # - job_name: rocketchat
+    # - job_name: sickchill
+    - job_name: sonarrx
+    - job_name: speedtest
+    # - job_name: sshwifty
+    # - job_name: stash
+    # - job_name: subsonic
+    # - job_name: synclounge
+    # - job_name: tdarr
+    # - job_name: telegraf
+    # - job_name: thelounge
+    - job_name: transfer
+    - job_name: transmission
+  # - job_name: transmissionvpn
+  # - job_name: transmissionx
+  # - job_name: ubooquity
+  # - job_name: unifi
+  # - job_name: unmanic
+  # - job_name: varken
+  # - job_name: vnstat
+  # - job_name: wallabag
+  # - job_name: watchtower
+  # - job_name: wordpress
+  # - job_name: xteve
+  # - job_name: znc
 
-  - job_name: airdcpp
-  - job_name: airsonic
-  - job_name: alltube
-  - job_name: alternatrr
-  - job_name: alternatrrx
-  - job_name: amongus
-  - job_name: apprise
-  - job_name: archivebox
-  - job_name: asshama
-  - job_name: autoscan
-  - job_name: bazarrx
-  - job_name: beets
-  - job_name: bitwarden
-  - job_name: booksonic
-  - job_name: bookstack
-  - job_name: btrfsmaintenance
-  - job_name: calibre
-  - job_name: calibre-web
-  - job_name: coder
-  - job_name: comicstreamer
-  - job_name: comixed
-  - job_name: couchpotato
-  - job_name: deemix
-  - job_name: deemixrr
-  - job_name: deezloader-remix
-  - job_name: deluge
-  - job_name: delugevpn
-  - job_name: emby2
-  - job_name: embystat
-  - job_name: epms
-  - job_name: filebot
-  - job_name: filebrowser
-  - job_name: filezilla
-  - job_name: flaresolverr
-  - job_name: funkwhale
-  - job_name: gazee
-  - job_name: glances
-  - job_name: goplaxt
-  - job_name: gotify
-  - job_name: grafana
-  - job_name: handbrake
-  - job_name: healthchecks
-  - job_name: heimdall
-  - job_name: influxdb
-  - job_name: invoiceninja
-  - job_name: jdownloader2
-  - job_name: jellyfin
-  - job_name: jirafeau
-  - job_name: kitana
-  - job_name: komga
-  - job_name: lazylibrarian
-  - job_name: lidarrx
-  - job_name: logarr
-  - job_name: mediabutler
-  - job_name: medusa
-  - job_name: minecraft
-  - job_name: monitorr
-  - job_name: mylar3
-  - job_name: navidrome
-  - job_name: nextcloud
-  - job_name: nowshowing
-  - job_name: nzbhydra
-  - job_name: ombi
-  - job_name: ombix
-  - job_name: organizrv1
-  - job_name: ouroboros
-  - job_name: overseerr
-  - job_name: petio
-  - job_name: plex2
-  - job_name: prowlarr
-  - job_name: pyload
-  - job_name: qbittorrent
-  - job_name: qbittorrentvpn
-  - job_name: quassel
-  - job_name: radarrx
-  - job_name: redbot
-  - job_name: requestrr
-  - job_name: requestrrx
-  - job_name: resilio-sync
-  - job_name: rocketchat
-  - job_name: sickchill
-  - job_name: sonarrx
-  - job_name: speedtest
-  - job_name: sshwifty
-  - job_name: stash
-  - job_name: subsonic
-  - job_name: synclounge
-  - job_name: tdarr
-  - job_name: telegraf
-  - job_name: thelounge
-  - job_name: transfer
-  - job_name: transmission
-  - job_name: transmissionvpn
-  - job_name: transmissionx
-  - job_name: ubooquity
-  - job_name: unifi
-  - job_name: unmanic
-  - job_name: varken
-  - job_name: vnstat
-  - job_name: wallabag
-  - job_name: watchtower
-  - job_name: wordpress
-  - job_name: xteve
-  - job_name: znc
-    
 install:
   - sh: |
       echo "=========================="

--- a/roles/speedtest/defaults/main.yml
+++ b/roles/speedtest/defaults/main.yml
@@ -1,10 +1,6 @@
 ##########################################################################
 # Title:         Community: speedtest | Default Variables                #
-<<<<<<< HEAD
 # Author(s):     salty, kowalski                                         #
-=======
-# Author(s):     salty kowalski                                          #
->>>>>>> feature-speedtest
 # URL:           https://github.com/saltyorg/Community                   #
 # --                                                                     #
 ##########################################################################
@@ -67,15 +63,9 @@ speedtest_docker_ports_defaults:
   - "{{ speedtest_web_port }}:{{ speedtest_web_port }}"
 speedtest_docker_ports_custom: []
 speedtest_docker_ports: "{{ speedtest_docker_ports_defaults
-<<<<<<< HEAD
                               + speedtest_docker_ports_custom
                           if (not reverse_proxy_is_enabled)
                           else [] + speedtest_docker_ports_custom }}"
-=======
-  + speedtest_docker_ports_custom
-  if (not reverse_proxy_is_enabled)
-  else [] + speedtest_docker_ports_custom }}"
->>>>>>> feature-speedtest
 
 # Envs
 speedtest_docker_envs_default:
@@ -91,58 +81,35 @@ speedtest_docker_envs: "{{ speedtest_docker_envs_default
 speedtest_docker_commands_default: []
 speedtest_docker_commands_custom: []
 speedtest_docker_commands: "{{ speedtest_docker_commands_default
-<<<<<<< HEAD
                              + speedtest_docker_commands_custom}}"
-=======
-  + speedtest_docker_commands_custom}}"
->>>>>>> feature-speedtest
 
 # Volumes
 speedtest_docker_volumes_default:
   - "{{ speedtest_paths_location }}:/var/www/html:rw"
 speedtest_docker_volumes_custom: []
 speedtest_docker_volumes: "{{ speedtest_docker_volumes_default
-<<<<<<< HEAD
                             + speedtest_docker_volumes_custom
                             + docker_volumes_downloads_common }}"
-=======
-  + speedtest_docker_volumes_custom
-  + docker_volumes_downloads_common }}"
->>>>>>> feature-speedtest
 
 # Devices
 speedtest_docker_devices_default: []
 speedtest_docker_devices_custom: []
 speedtest_docker_devices: "{{ speedtest_docker_devices_default
-<<<<<<< HEAD
                             + speedtest_docker_devices_custom }}"
-=======
-  + speedtest_docker_devices_custom }}"
->>>>>>> feature-speedtest
 
 # Hosts
 speedtest_docker_hosts_default: []
 speedtest_docker_hosts_custom: []
 speedtest_docker_hosts: "{{ docker_hosts_common
-<<<<<<< HEAD
                           | combine(speedtest_docker_hosts_default)
                           | combine(speedtest_docker_hosts_custom) }}"
-=======
-  | combine(speedtest_docker_hosts_default)
-  | combine(speedtest_docker_hosts_custom) }}"
->>>>>>> feature-speedtest
 
 # Labels
 speedtest_docker_labels_default: {}
 speedtest_docker_labels_custom: {}
 speedtest_docker_labels: "{{ docker_labels_common
-<<<<<<< HEAD
                            | combine(speedtest_docker_labels_default)
                            | combine(speedtest_docker_labels_custom) }}"
-=======
-  | combine(speedtest_docker_labels_default)
-  | combine(speedtest_docker_labels_custom) }}"
->>>>>>> feature-speedtest
 
 # Hostname
 speedtest_docker_hostname: "{{ speedtest_name }}"
@@ -152,33 +119,20 @@ speedtest_docker_networks_alias: "{{ speedtest_name }}"
 speedtest_docker_networks_default: []
 speedtest_docker_networks_custom: []
 speedtest_docker_networks: "{{ docker_networks_common
-<<<<<<< HEAD
                              + speedtest_docker_networks_default
                              + speedtest_docker_networks_custom }}"
-=======
-  + speedtest_docker_networks_default
-  + speedtest_docker_networks_custom }}"
->>>>>>> feature-speedtest
 
 # Capabilities
 speedtest_docker_capabilities_default: []
 speedtest_docker_capabilities_custom: []
 speedtest_docker_capabilities: "{{ speedtest_docker_capabilities_default
-<<<<<<< HEAD
                                  + speedtest_docker_capabilities_custom }}"
-=======
-  + speedtest_docker_capabilities_custom }}"
->>>>>>> feature-speedtest
 
 # Security Opts
 speedtest_docker_security_opts_default: []
 speedtest_docker_security_opts_custom: []
 speedtest_docker_security_opts: "{{ speedtest_docker_security_opts_default
-<<<<<<< HEAD
                                   + speedtest_docker_security_opts_custom }}"
-=======
-  + speedtest_docker_security_opts_custom }}"
->>>>>>> feature-speedtest
 
 # Restart Policy
 speedtest_docker_restart_policy: unless-stopped

--- a/roles/speedtest/defaults/main.yml
+++ b/roles/speedtest/defaults/main.yml
@@ -1,0 +1,141 @@
+##########################################################################
+# Title:         Community: speedtest | Default Variables                #
+# Author(s):     salty kowalski                                          #
+# URL:           https://github.com/saltyorg/Community                   #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+speedtest_name: speedtest
+
+################################
+# Paths
+################################
+
+speedtest_paths_folder: "{{ speedtest_name }}"
+speedtest_paths_location: "{{ server_appdata_path }}/{{ speedtest_paths_folder }}"
+speedtest_paths_folders_list:
+  - "{{ speedtest_paths_location }}"
+
+################################
+# Web
+################################
+
+speedtest_web_subdomain: "{{ speedtest_name }}"
+speedtest_web_domain: "{{ user.domain }}"
+speedtest_web_port: "80"
+
+################################
+# DNS
+################################
+
+speedtest_dns_record: "{{ speedtest_web_subdomain }}"
+speedtest_dns_zone: "{{ speedtest_web_domain }}"
+
+################################
+# Traefik
+################################
+
+speedtest_traefik_middleware: "secureHeaders@file,gzip"
+speedtest_traefik_host: "{{ speedtest_web_subdomain + '.' + speedtest_web_domain }}"
+speedtest_traefik_certresolver: "{{ traefik_default_certresolver }}"
+speedtest_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+speedtest_docker_container: "{{ speedtest_name }}"
+
+# Image
+speedtest_docker_image_pull: true
+speedtest_docker_image_tag: "latest"
+speedtest_docker_image: "satzisa/html5-speedtest:{{ speedtest_docker_image_tag }}"
+
+# Ports
+speedtest_docker_ports_defaults:
+  - "{{ speedtest_web_port }}:{{ speedtest_web_port }}"
+speedtest_docker_ports_custom: []
+speedtest_docker_ports: "{{ speedtest_docker_ports_defaults
+  + speedtest_docker_ports_custom
+  if (not reverse_proxy_is_enabled)
+  else [] + speedtest_docker_ports_custom }}"
+
+# Envs
+speedtest_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  UMASK: "002"
+  TZ: "{{ tz }}"
+speedtest_docker_envs_custom: {}
+speedtest_docker_envs: "{{ speedtest_docker_envs_default
+  | combine(speedtest_docker_envs_custom) }}"
+
+# Commands
+speedtest_docker_commands_default: []
+speedtest_docker_commands_custom: []
+speedtest_docker_commands: "{{ speedtest_docker_commands_default
+  + speedtest_docker_commands_custom}}"
+
+# Volumes
+speedtest_docker_volumes_default:
+  - "{{ speedtest_paths_location }}:/var/www/html:rw"
+speedtest_docker_volumes_custom: []
+speedtest_docker_volumes: "{{ speedtest_docker_volumes_default
+  + speedtest_docker_volumes_custom
+  + docker_volumes_downloads_common }}"
+
+# Devices
+speedtest_docker_devices_default: []
+speedtest_docker_devices_custom: []
+speedtest_docker_devices: "{{ speedtest_docker_devices_default
+  + speedtest_docker_devices_custom }}"
+
+# Hosts
+speedtest_docker_hosts_default: []
+speedtest_docker_hosts_custom: []
+speedtest_docker_hosts: "{{ docker_hosts_common
+  | combine(speedtest_docker_hosts_default)
+  | combine(speedtest_docker_hosts_custom) }}"
+
+# Labels
+speedtest_docker_labels_default: {}
+speedtest_docker_labels_custom: {}
+speedtest_docker_labels: "{{ docker_labels_common
+  | combine(speedtest_docker_labels_default)
+  | combine(speedtest_docker_labels_custom) }}"
+
+# Hostname
+speedtest_docker_hostname: "{{ speedtest_name }}"
+
+# Networks
+speedtest_docker_networks_alias: "{{ speedtest_name }}"
+speedtest_docker_networks_default: []
+speedtest_docker_networks_custom: []
+speedtest_docker_networks: "{{ docker_networks_common
+  + speedtest_docker_networks_default
+  + speedtest_docker_networks_custom }}"
+
+# Capabilities
+speedtest_docker_capabilities_default: []
+speedtest_docker_capabilities_custom: []
+speedtest_docker_capabilities: "{{ speedtest_docker_capabilities_default
+  + speedtest_docker_capabilities_custom }}"
+
+# Security Opts
+speedtest_docker_security_opts_default: []
+speedtest_docker_security_opts_custom: []
+speedtest_docker_security_opts: "{{ speedtest_docker_security_opts_default
+  + speedtest_docker_security_opts_custom }}"
+
+# Restart Policy
+speedtest_docker_restart_policy: unless-stopped
+
+# State
+speedtest_docker_state: started

--- a/roles/speedtest/defaults/main.yml
+++ b/roles/speedtest/defaults/main.yml
@@ -1,6 +1,6 @@
 ##########################################################################
 # Title:         Community: speedtest | Default Variables                #
-# Author(s):     salty kowalski                                          #
+# Author(s):     salty, kowalski                                         #
 # URL:           https://github.com/saltyorg/Community                   #
 # --                                                                     #
 ##########################################################################
@@ -63,9 +63,9 @@ speedtest_docker_ports_defaults:
   - "{{ speedtest_web_port }}:{{ speedtest_web_port }}"
 speedtest_docker_ports_custom: []
 speedtest_docker_ports: "{{ speedtest_docker_ports_defaults
-  + speedtest_docker_ports_custom
-  if (not reverse_proxy_is_enabled)
-  else [] + speedtest_docker_ports_custom }}"
+                              + speedtest_docker_ports_custom
+                          if (not reverse_proxy_is_enabled)
+                          else [] + speedtest_docker_ports_custom }}"
 
 # Envs
 speedtest_docker_envs_default:
@@ -81,35 +81,35 @@ speedtest_docker_envs: "{{ speedtest_docker_envs_default
 speedtest_docker_commands_default: []
 speedtest_docker_commands_custom: []
 speedtest_docker_commands: "{{ speedtest_docker_commands_default
-  + speedtest_docker_commands_custom}}"
+                             + speedtest_docker_commands_custom}}"
 
 # Volumes
 speedtest_docker_volumes_default:
   - "{{ speedtest_paths_location }}:/var/www/html:rw"
 speedtest_docker_volumes_custom: []
 speedtest_docker_volumes: "{{ speedtest_docker_volumes_default
-  + speedtest_docker_volumes_custom
-  + docker_volumes_downloads_common }}"
+                            + speedtest_docker_volumes_custom
+                            + docker_volumes_downloads_common }}"
 
 # Devices
 speedtest_docker_devices_default: []
 speedtest_docker_devices_custom: []
 speedtest_docker_devices: "{{ speedtest_docker_devices_default
-  + speedtest_docker_devices_custom }}"
+                            + speedtest_docker_devices_custom }}"
 
 # Hosts
 speedtest_docker_hosts_default: []
 speedtest_docker_hosts_custom: []
 speedtest_docker_hosts: "{{ docker_hosts_common
-  | combine(speedtest_docker_hosts_default)
-  | combine(speedtest_docker_hosts_custom) }}"
+                          | combine(speedtest_docker_hosts_default)
+                          | combine(speedtest_docker_hosts_custom) }}"
 
 # Labels
 speedtest_docker_labels_default: {}
 speedtest_docker_labels_custom: {}
 speedtest_docker_labels: "{{ docker_labels_common
-  | combine(speedtest_docker_labels_default)
-  | combine(speedtest_docker_labels_custom) }}"
+                           | combine(speedtest_docker_labels_default)
+                           | combine(speedtest_docker_labels_custom) }}"
 
 # Hostname
 speedtest_docker_hostname: "{{ speedtest_name }}"
@@ -119,20 +119,20 @@ speedtest_docker_networks_alias: "{{ speedtest_name }}"
 speedtest_docker_networks_default: []
 speedtest_docker_networks_custom: []
 speedtest_docker_networks: "{{ docker_networks_common
-  + speedtest_docker_networks_default
-  + speedtest_docker_networks_custom }}"
+                             + speedtest_docker_networks_default
+                             + speedtest_docker_networks_custom }}"
 
 # Capabilities
 speedtest_docker_capabilities_default: []
 speedtest_docker_capabilities_custom: []
 speedtest_docker_capabilities: "{{ speedtest_docker_capabilities_default
-  + speedtest_docker_capabilities_custom }}"
+                                 + speedtest_docker_capabilities_custom }}"
 
 # Security Opts
 speedtest_docker_security_opts_default: []
 speedtest_docker_security_opts_custom: []
 speedtest_docker_security_opts: "{{ speedtest_docker_security_opts_default
-  + speedtest_docker_security_opts_custom }}"
+                                  + speedtest_docker_security_opts_custom }}"
 
 # Restart Policy
 speedtest_docker_restart_policy: unless-stopped

--- a/roles/speedtest/defaults/main.yml
+++ b/roles/speedtest/defaults/main.yml
@@ -63,9 +63,9 @@ speedtest_docker_ports_defaults:
   - "{{ speedtest_web_port }}:{{ speedtest_web_port }}"
 speedtest_docker_ports_custom: []
 speedtest_docker_ports: "{{ speedtest_docker_ports_defaults
-                              + speedtest_docker_ports_custom
-                          if (not reverse_proxy_is_enabled)
-                          else [] + speedtest_docker_ports_custom }}"
+                            + speedtest_docker_ports_custom
+                            if (not reverse_proxy_is_enabled)
+                            else [] + speedtest_docker_ports_custom }}"
 
 # Envs
 speedtest_docker_envs_default:
@@ -75,41 +75,41 @@ speedtest_docker_envs_default:
   TZ: "{{ tz }}"
 speedtest_docker_envs_custom: {}
 speedtest_docker_envs: "{{ speedtest_docker_envs_default
-  | combine(speedtest_docker_envs_custom) }}"
+                           | combine(speedtest_docker_envs_custom) }}"
 
 # Commands
 speedtest_docker_commands_default: []
 speedtest_docker_commands_custom: []
 speedtest_docker_commands: "{{ speedtest_docker_commands_default
-                             + speedtest_docker_commands_custom}}"
+                               + speedtest_docker_commands_custom}}"
 
 # Volumes
 speedtest_docker_volumes_default:
   - "{{ speedtest_paths_location }}:/var/www/html:rw"
 speedtest_docker_volumes_custom: []
 speedtest_docker_volumes: "{{ speedtest_docker_volumes_default
-                            + speedtest_docker_volumes_custom
-                            + docker_volumes_downloads_common }}"
+                              + speedtest_docker_volumes_custom
+                              + docker_volumes_downloads_common }}"
 
 # Devices
 speedtest_docker_devices_default: []
 speedtest_docker_devices_custom: []
 speedtest_docker_devices: "{{ speedtest_docker_devices_default
-                            + speedtest_docker_devices_custom }}"
+                              + speedtest_docker_devices_custom }}"
 
 # Hosts
 speedtest_docker_hosts_default: []
 speedtest_docker_hosts_custom: []
 speedtest_docker_hosts: "{{ docker_hosts_common
-                          | combine(speedtest_docker_hosts_default)
-                          | combine(speedtest_docker_hosts_custom) }}"
+                            | combine(speedtest_docker_hosts_default)
+                            | combine(speedtest_docker_hosts_custom) }}"
 
 # Labels
 speedtest_docker_labels_default: {}
 speedtest_docker_labels_custom: {}
 speedtest_docker_labels: "{{ docker_labels_common
-                           | combine(speedtest_docker_labels_default)
-                           | combine(speedtest_docker_labels_custom) }}"
+                             | combine(speedtest_docker_labels_default)
+                             | combine(speedtest_docker_labels_custom) }}"
 
 # Hostname
 speedtest_docker_hostname: "{{ speedtest_name }}"
@@ -119,20 +119,20 @@ speedtest_docker_networks_alias: "{{ speedtest_name }}"
 speedtest_docker_networks_default: []
 speedtest_docker_networks_custom: []
 speedtest_docker_networks: "{{ docker_networks_common
-                             + speedtest_docker_networks_default
-                             + speedtest_docker_networks_custom }}"
+                               + speedtest_docker_networks_default
+                               + speedtest_docker_networks_custom }}"
 
 # Capabilities
 speedtest_docker_capabilities_default: []
 speedtest_docker_capabilities_custom: []
 speedtest_docker_capabilities: "{{ speedtest_docker_capabilities_default
-                                 + speedtest_docker_capabilities_custom }}"
+                                   + speedtest_docker_capabilities_custom }}"
 
 # Security Opts
 speedtest_docker_security_opts_default: []
 speedtest_docker_security_opts_custom: []
 speedtest_docker_security_opts: "{{ speedtest_docker_security_opts_default
-                                  + speedtest_docker_security_opts_custom }}"
+                                    + speedtest_docker_security_opts_custom }}"
 
 # Restart Policy
 speedtest_docker_restart_policy: unless-stopped

--- a/roles/speedtest/tasks/main.yml
+++ b/roles/speedtest/tasks/main.yml
@@ -1,7 +1,7 @@
 #########################################################################
 # Title:            Community: Speedtest Server                         #
-# Author(s):        Satz kowalski                                       #
-# URL:           https://github.com/saltyorg/Community                  #
+# Author(s):        Satz, kowalski                                      #
+# URL:              https://github.com/saltyorg/Community               #
 # Docker Image(s):  satzisa/html5-speedtest                             #
 # --                                                                    #
 #########################################################################

--- a/roles/speedtest/tasks/main.yml
+++ b/roles/speedtest/tasks/main.yml
@@ -9,7 +9,6 @@
 #                   GNU General Public License v3.0                     #
 #########################################################################
 ---
----
 - name: Add DNS record
   include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
   vars:

--- a/roles/speedtest/tasks/main.yml
+++ b/roles/speedtest/tasks/main.yml
@@ -1,7 +1,7 @@
 #########################################################################
 # Title:            Community: Speedtest Server                         #
-# Author(s):        Satz                                                #
-# URL:              https://github.com/Cloudbox/Community               #
+# Author(s):        Satz kowalski                                       #
+# URL:           https://github.com/saltyorg/Community                  #
 # Docker Image(s):  satzisa/html5-speedtest                             #
 # --                                                                    #
 #         Part of the Cloudbox project: https://cloudbox.works          #
@@ -9,42 +9,22 @@
 #                   GNU General Public License v3.0                     #
 #########################################################################
 ---
-- name: "Set DNS Record on CloudFlare"
-  include_role:
-    name: cloudflare-dns
+---
+- name: Add DNS record
+  include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
   vars:
-    record: speedtest
-  when: cloudflare_enabled
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
 
-- name: Stop and remove any existing container
+- name: Remove existing Docker container
   docker_container:
-    name: speedtest
+    name: "{{ lookup('vars', role_name + '_docker_container') }}"
     state: absent
+    container_default_behavior: compatibility
 
-- name: Create speedtest directories
-  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }} recurse=yes"
-  with_items:
-    - /opt/speedtest/
+- name: Create directories
+  file: "path={{ item }} state=directory owner={{ user.name }} group={{ user.name }} mode=0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
 
-- name: Create and start container
-  docker_container:
-    name: speedtest
-    image: "satzisa/html5-speedtest"
-    pull: yes
-    env:
-      TZ: "{{ tz }}"
-      UID: "{{ uid }}"
-      GID: "{{ gid }}"
-      VIRTUAL_HOST: "speedtest.{{ user.domain }}"
-      VIRTUAL_PORT: "80"
-      LETSENCRYPT_HOST: "speedtest.{{ user.domain }}"
-      LETSENCRYPT_EMAIL: "{{ user.email }}"
-    volumes:
-      - "/opt/speedtest:/var/www/html:rw"
-    networks:
-      - name: cloudbox
-        aliases:
-          - speedtest
-    purge_networks: yes
-    restart_policy: unless-stopped
-    state: started
+- name: Create Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/speedtest/tasks/main.yml
+++ b/roles/speedtest/tasks/main.yml
@@ -1,12 +1,7 @@
 #########################################################################
 # Title:            Community: Speedtest Server                         #
-<<<<<<< HEAD
 # Author(s):        Satz, kowalski                                      #
 # URL:              https://github.com/saltyorg/Community               #
-=======
-# Author(s):        Satz kowalski                                       #
-# URL:           https://github.com/saltyorg/Community                  #
->>>>>>> feature-speedtest
 # Docker Image(s):  satzisa/html5-speedtest                             #
 # --                                                                    #
 #########################################################################

--- a/roles/speedtest/tasks/main.yml
+++ b/roles/speedtest/tasks/main.yml
@@ -4,7 +4,6 @@
 # URL:           https://github.com/saltyorg/Community                  #
 # Docker Image(s):  satzisa/html5-speedtest                             #
 # --                                                                    #
-#         Part of the Cloudbox project: https://cloudbox.works          #
 #########################################################################
 #                   GNU General Public License v3.0                     #
 #########################################################################


### PR DESCRIPTION
# Description
Repair of speedtest role.

Motivation and context. 
Crushed that salty rejected my hard work on sanity checking and looking for redemption.
Inferior sanity checking fix merged and speedtest now works.

# How Has This Been Tested?
```
➜  community git:(feature-speedtest) sb install cm-speedtest

PLAY RECAP 
localhost                  : ok=20   changed=4    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0
```

# New Role Checklist:

- [x ] I have updated the header in any files I may have used as templates with my own information
- [y ] I have verified that any Docker images used are current and supported.
As mentioned, docker image is two years unmaintained.
