### PR TITLE
lazy librarian salt convert

### DIFF
--- a/community.yml
+++ b/community.yml
@@ -62,7 +62,7 @@
     - { role: kcptun_server, tags: ['kcptun-server'] }
     - { role: kitana, tags: ['kitana'] }
     - { role: komga, tags: ['komga'] }
-    # - { role: lazylibrarian, tags: ['lazylibrarian'] }
+    - { role: lazylibrarian, tags: ['lazylibrarian'] }
     - { role: lidarrx, tags: ['lidarrx'] }
     - { role: logarr, tags: ['logarr'] }
     # - { role: mediabutler, tags: ['mediabutler'] }

--- a/roles/lazylibrarian/defaults/main.yml
+++ b/roles/lazylibrarian/defaults/main.yml
@@ -1,0 +1,144 @@
+##########################################################################
+# Title:            Community: LazyLibrarian                             #
+# Author(s):        Superduper09, kowalski                               #
+# URL:              https://github.com/saltyorg/Community                #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+lazylibrarian_name: lazylibrarian
+
+################################
+# Paths
+################################
+
+lazylibrarian_paths_folder: "{{ lazylibrarian_name }}"
+lazylibrarian_paths_location: "{{ server_appdata_path }}/{{ lazylibrarian_paths_folder }}"
+lazylibrarian_paths_folders_list:
+  - "{{ lazylibrarian_paths_location }}"
+
+################################
+# Web
+################################
+
+lazylibrarian_web_subdomain: "{{ lazylibrarian_name }}"
+lazylibrarian_web_domain: "{{ user.domain }}"
+lazylibrarian_web_port: "5299"
+lazylibrarian_web_url: "{{ 'https://' + lazylibrarian_web_subdomain + '.' + lazylibrarian_web_domain
+                        if (reverse_proxy_is_enabled)
+                        else 'http://localhost:' + lazylibrarian_web_port }}"
+
+################################
+# DNS
+################################
+
+lazylibrarian_dns_record: "{{ lazylibrarian_web_subdomain }}"
+lazylibrarian_dns_zone: "{{ lazylibrarian_web_domain }}"
+
+################################
+# Traefik
+################################
+
+lazylibrarian_traefik_middleware: "{{ traefik_default_middleware }}"
+lazylibrarian_traefik_certresolver: "{{ traefik_default_certresolver }}"
+lazylibrarian_traefik_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+lazylibrarian_docker_container: "{{ lazylibrarian_name }}"
+
+# Image
+lazylibrarian_docker_image_pull: true
+lazylibrarian_docker_image_tag: "latest"
+lazylibrarian_docker_image: "lscr.io/linuxserver/lazylibrarian:{{ lazylibrarian_docker_image_tag }}"
+
+# Ports
+lazylibrarian_docker_ports_defaults:
+  - "{{ lazylibrarian_web_port }}"
+lazylibrarian_docker_ports_custom: []
+lazylibrarian_docker_ports: "{{ lazylibrarian_docker_ports_defaults
+                                + lazylibrarian_docker_ports_custom
+                             if (not reverse_proxy_is_enabled)
+                             else [] + lazylibrarian_docker_ports_custom }}"
+
+# Envs
+lazylibrarian_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+  DOCKER_MODS: "linuxserver/calibre-web:calibre|linuxserver/mods:lazylibrarian-ffmpeg"
+lazylibrarian_docker_envs_custom: {}
+lazylibrarian_docker_envs: "{{ lazylibrarian_docker_envs_default
+                               | combine(lazylibrarian_docker_envs_custom) }}"
+
+# Commands
+lazylibrarian_docker_commands_default: []
+lazylibrarian_docker_commands_custom: []
+lazylibrarian_docker_commands: "{{ lazylibrarian_docker_commands_default
+                                   + lazylibrarian_docker_commands_custom }}"
+
+# Volumes
+lazylibrarian_docker_volumes_default:
+  - "{{ lazylibrarian_paths_location }}:/config"
+  - "/mnt:/mnt"
+lazylibrarian_docker_volumes_custom: []
+lazylibrarian_docker_volumes: "{{ lazylibrarian_docker_volumes_default
+                                  + lazylibrarian_docker_volumes_custom
+                                  + docker_volumes_downloads_common }}"
+
+# Devices
+lazylibrarian_docker_devices_default: []
+lazylibrarian_docker_devices_custom: []
+lazylibrarian_docker_devices: "{{ lazylibrarian_docker_devices_default
+                                  + lazylibrarian_docker_devices_custom }}"
+
+# Hosts
+lazylibrarian_docker_hosts_default: []
+lazylibrarian_docker_hosts_custom: []
+lazylibrarian_docker_hosts: "{{ docker_hosts_common
+                                | combine(lazylibrarian_docker_hosts_default)
+                                | combine(lazylibrarian_docker_hosts_custom) }}"
+
+# Labels
+lazylibrarian_docker_labels_default: {}
+lazylibrarian_docker_labels_custom: {}
+lazylibrarian_docker_labels: "{{ docker_labels_common
+                                 | combine(lazylibrarian_docker_labels_default)
+                                 | combine(lazylibrarian_docker_labels_custom) }}"
+
+# Hostname
+lazylibrarian_docker_hostname: "{{ lazylibrarian_name }}"
+
+# Networks
+lazylibrarian_docker_networks_alias: "{{ lazylibrarian_name }}"
+lazylibrarian_docker_networks_default: []
+lazylibrarian_docker_networks_custom: []
+lazylibrarian_docker_networks: "{{ docker_networks_common
+                                   + lazylibrarian_docker_networks_default
+                                   + lazylibrarian_docker_networks_custom }}"
+
+# Capabilities
+lazylibrarian_docker_capabilities_default: []
+lazylibrarian_docker_capabilities_custom: []
+lazylibrarian_docker_capabilities: "{{ lazylibrarian_docker_capabilities_default
+                                       + lazylibrarian_docker_capabilities_custom }}"
+
+# Security Opts
+lazylibrarian_docker_security_opts_default: []
+lazylibrarian_docker_security_opts_custom: []
+lazylibrarian_docker_security_opts: "{{ lazylibrarian_docker_security_opts_default
+                                        + lazylibrarian_docker_security_opts_custom }}"
+
+# Restart Policy
+lazylibrarian_docker_restart_policy: unless-stopped
+
+# State
+lazylibrarian_docker_state: started

--- a/roles/lazylibrarian/tasks/main.yml
+++ b/roles/lazylibrarian/tasks/main.yml
@@ -1,51 +1,29 @@
-#########################################################################
-# Title:            Community: LazyLibrarian                            #
-# Author(s):        Superduper09                                        #
-# URL:              https://github.com/saltyorg/Community               #
-# --                                                                    #
-#########################################################################
-#                   GNU General Public License v3.0                     #
-#########################################################################
+##########################################################################
+# Title:            Community: LazyLibrarian                             #
+# Author(s):        Superduper09, kowalski                               #
+# URL:              https://github.com/saltyorg/Community                #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
 ---
-- name: "Setting CloudFlare DNS Record"
-  include_role:
-    name: cloudflare-dns
+- name: Add DNS record
+  include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
   vars:
-    record: lazylibrarian
-  when: cloudflare_enabled
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
 
-- name: Stop and remove any existing container
-  docker_container:
-    name: lazylibrarian
-    state: absent
+- name: Remove existing Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
 
-- name: Create lazylibrarian directories
-  file: "path={{ item }} state=directory mode=0775 owner={{ user.name }} group={{ user.name }}"
-  with_items:
-    - /opt/lazylibrarian
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
 
-- name: Create and start container
-  docker_container:
-    name: lazylibrarian
-    image: thraxis/lazylibrarian-calibre
-    pull: yes
-    env:
-      TZ: "{{ tz }}"
-      PUID: "{{ uid }}"
-      PGID: "{{ gid }}"
-      VIRTUAL_HOST: "lazylibrarian.{{ user.domain }}"
-      VIRTUAL_PORT: "5299"
-      LETSENCRYPT_HOST: "lazylibrarian.{{ user.domain }}"
-      LETSENCRYPT_EMAIL: "{{ user.email }}"
-    volumes:
-      - "/opt/lazylibrarian:/config"
-      - "/mnt:/mnt"
-    labels:
-      "com.github.cloudbox.cloudbox_managed": "true"
-    networks:
-      - name: cloudbox
-        aliases:
-          - lazylibrarian
-    purge_networks: yes
-    restart_policy: unless-stopped
-    state: started
+- name: Create Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"


### PR DESCRIPTION
# Description

Convert lazy librarian to saltbox format.

Switched to lsio container with calibre option for book conversions.

# How Has This Been Tested?

Install on saltbox server and basic config

- [ ] create admin user
- [ ] log in log out

# New Role Checklist:

- [ ] I have updated the header in any files I may have used as templates with my own information
- [ ] I have added my new role to `community.yml`
- [ ] I have verified that any Docker images used are current and supported.

