### PR TITLE
mkvtoolnix: New role

### DIFF
--- a/community.yml
+++ b/community.yml
@@ -73,7 +73,7 @@
     - { role: monitorr, tags: ['monitorr'] }
     - { role: moviematch, tags: ['moviematch'] }
     - { role: mylar3, tags: ['mylar3'] }
-    - { role: mkvtoolnix, tags: ['mkvtoolnix'] }    
+    - { role: mkvtoolnix, tags: ['mkvtoolnix'] }
     - { role: navidrome, tags: ['navidrome'] }
     - { role: nextcloud, tags: ['nextcloud'] }
     - { role: ombi, tags: ['ombi'] }

--- a/community.yml
+++ b/community.yml
@@ -73,6 +73,7 @@
     - { role: monitorr, tags: ['monitorr'] }
     - { role: moviematch, tags: ['moviematch'] }
     - { role: mylar3, tags: ['mylar3'] }
+    - { role: mkvtoolnix, tags: ['mkvtoolnix'] }    
     - { role: navidrome, tags: ['navidrome'] }
     - { role: nextcloud, tags: ['nextcloud'] }
     - { role: ombi, tags: ['ombi'] }

--- a/roles/mkvtoolnix/defaults/main.yml
+++ b/roles/mkvtoolnix/defaults/main.yml
@@ -1,0 +1,147 @@
+##########################################################################
+# Title:         Community: mkvtoolnix | Default Variables               #
+# Author(s):     sevos                                                   #
+# URL:           https://github.com/saltyorg/Community                   #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+mkvtoolnix_name: mkvtoolnix
+
+################################
+# Paths
+################################
+
+mkvtoolnix_paths_folder: "{{ mkvtoolnix_name }}"
+mkvtoolnix_paths_location: "{{ server_appdata_path }}/{{ mkvtoolnix_paths_folder }}"
+mkvtoolnix_paths_folders_list:
+  - "{{ mkvtoolnix_paths_location }}"
+
+################################
+# Web
+################################
+
+mkvtoolnix_web_subdomain: "{{ mkvtoolnix_name }}"
+mkvtoolnix_web_domain: "{{ user.domain }}"
+mkvtoolnix_web_port: "5800"
+mkvtoolnix_web_url: "{{ 'https://' + mkvtoolnix_web_subdomain + '.' + mkvtoolnix_web_domain
+                   if (reverse_proxy_is_enabled)
+                   else 'http://localhost:' + mkvtoolnix_web_port }}"
+
+################################
+# DNS
+################################
+
+mkvtoolnix_dns_record: "{{ mkvtoolnix_web_subdomain }}"
+mkvtoolnix_dns_zone: "{{ mkvtoolnix_web_domain }}"
+
+################################
+# Traefik
+################################
+
+mkvtoolnix_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+mkvtoolnix_traefik_middleware: "{{ traefik_default_middleware + ',' + mkvtoolnix_traefik_sso_middleware
+                            if (mkvtoolnix_traefik_sso_middleware | length > 0) 
+                            else traefik_default_middleware }}"
+mkvtoolnix_traefik_certresolver: "{{ traefik_default_certresolver }}"
+mkvtoolnix_traefik_enabled: true
+mkvtoolnix_traefik_api_enabled: true
+
+################################
+# Docker
+################################
+
+# Container
+mkvtoolnix_docker_container: "{{ mkvtoolnix_name }}"
+
+# Image
+mkvtoolnix_docker_image_pull: true
+mkvtoolnix_docker_image_tag: "latest"
+mkvtoolnix_docker_image: "jlesage/mkvtoolnix:{{ mkvtoolnix_docker_image_tag }}"
+
+# Ports
+mkvtoolnix_docker_ports_defaults:
+  - "{{ mkvtoolnix_web_port }}"
+mkvtoolnix_docker_ports_custom: []
+mkvtoolnix_docker_ports: "{{ mkvtoolnix_docker_ports_defaults
+                         + mkvtoolnix_docker_ports_custom
+                      if (not reverse_proxy_is_enabled)
+                      else [] + mkvtoolnix_docker_ports_custom }}"
+
+# Envs
+mkvtoolnix_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+mkvtoolnix_docker_envs_custom: {}
+mkvtoolnix_docker_envs: "{{ mkvtoolnix_docker_envs_default
+                        | combine(mkvtoolnix_docker_envs_custom) }}"
+
+# Commands
+mkvtoolnix_docker_commands_default: []
+mkvtoolnix_docker_commands_custom: []
+mkvtoolnix_docker_commands: "{{ mkvtoolnix_docker_commands_default
+                            + mkvtoolnix_docker_commands_custom }}"
+
+# Volumes
+mkvtoolnix_docker_volumes_default:
+  - "{{ mkvtoolnix_paths_location }}:/config:rw"
+  - "/mnt/unionfs:/storage"
+  - "/mnt:/mnt"
+mkvtoolnix_docker_volumes_custom: []
+bazarr_docker_volumes_theme: []
+mkvtoolnix_docker_volumes: "{{ mkvtoolnix_docker_volumes_default }}"
+
+# Devices
+mkvtoolnix_docker_devices_default: []
+mkvtoolnix_docker_devices_custom: []
+mkvtoolnix_docker_devices: "{{ mkvtoolnix_docker_devices_default
+                           + mkvtoolnix_docker_devices_custom }}"
+
+# Hosts
+mkvtoolnix_docker_hosts_default: []
+mkvtoolnix_docker_hosts_custom: []
+mkvtoolnix_docker_hosts: "{{ docker_hosts_common
+                         | combine(mkvtoolnix_docker_hosts_default)
+                         | combine(mkvtoolnix_docker_hosts_custom) }}"
+
+# Labels
+mkvtoolnix_docker_labels_default: {}
+mkvtoolnix_docker_labels_custom: {}
+mkvtoolnix_docker_labels: "{{ docker_labels_common
+                          | combine(mkvtoolnix_docker_labels_default)
+                          | combine(mkvtoolnix_docker_labels_custom) }}"
+
+# Hostname
+mkvtoolnix_docker_hostname: "{{ mkvtoolnix_name }}"
+
+# Networks
+mkvtoolnix_docker_networks_alias: "{{ mkvtoolnix_name }}"
+mkvtoolnix_docker_networks_default: []
+mkvtoolnix_docker_networks_custom: []
+mkvtoolnix_docker_networks: "{{ docker_networks_common
+                            + mkvtoolnix_docker_networks_default
+                            + mkvtoolnix_docker_networks_custom }}"
+
+# Capabilities
+mkvtoolnix_docker_capabilities_default: []
+mkvtoolnix_docker_capabilities_custom: []
+mkvtoolnix_docker_capabilities: "{{ mkvtoolnix_docker_capabilities_default
+                                + mkvtoolnix_docker_capabilities_custom }}"
+
+# Security Opts
+mkvtoolnix_docker_security_opts_default: []
+mkvtoolnix_docker_security_opts_custom: []
+mkvtoolnix_docker_security_opts: "{{ mkvtoolnix_docker_security_opts_default
+                                 + mkvtoolnix_docker_security_opts_custom }}"
+
+# Restart Policy
+mkvtoolnix_docker_restart_policy: unless-stopped
+
+# State
+mkvtoolnix_docker_state: started

--- a/roles/mkvtoolnix/tasks/main.yml
+++ b/roles/mkvtoolnix/tasks/main.yml
@@ -1,0 +1,29 @@
+#########################################################################
+# Title:            Community: MKVToolNix                               #
+# Author(s):        sevos                                               #
+# URL:              https://github.com/saltyorg/Community               #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+
+- name: Remove existing Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+- name: Create Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"


### PR DESCRIPTION
# Description

MKVToolNix is a small collection of tools (mkvmerge, mkvinfo, mkvextract, mkvpropedit and mmg) that allows you to manipulate Matroska (MKV) files in several ways.

The following role `mkvtoolnix` uses a Docker image `jlesage/mkvtoolnix` which is shipped with VNC. Due to security reasons (access to files), Authelia middleware was used here.

# How Has This Been Tested?

I've run the role and everything worked as expected.

# New Role Checklist:

- [❌] <not ready yet> I have reviewed the [Contribute page in the wiki](https://docs.saltbox.dev/xxxx)
- [✔️] I have updated the header in any files I may have used as templates with my own information
- [✔️] I have added my new role to `community.yml`
- [✔️] I have verified that any Docker images used are current and supported.
- [❌] I have made corresponding changes to the documentation or have submitted a separate PR to the docs repo for this purpose.
