### PR TITLE
AdGuard Home: New role

### DIFF
--- a/community.yml
+++ b/community.yml
@@ -11,6 +11,7 @@
     - { role: sanity_check, tags: ['always', 'sanity_check'] }
     - { role: pre_tasks, tags: ['pre_tasks'] }
     # Apps
+    - { role: adguardhome, tags: ['adguardhome'] }
     - { role: airdcpp, tags: ['airdcpp'] }
     - { role: airsonic, tags: ['airsonic'] }
     - { role: alltube, tags: ['alltube'] }
@@ -73,6 +74,7 @@
     - { role: monitorr, tags: ['monitorr'] }
     - { role: moviematch, tags: ['moviematch'] }
     - { role: mylar3, tags: ['mylar3'] }
+    - { role: mkvtoolnix, tags: ['mkvtoolnix'] }
     - { role: navidrome, tags: ['navidrome'] }
     - { role: nextcloud, tags: ['nextcloud'] }
     - { role: ombi, tags: ['ombi'] }

--- a/roles/adguardhome/defaults/main.yml
+++ b/roles/adguardhome/defaults/main.yml
@@ -1,0 +1,152 @@
+##########################################################################
+# Title:         Community: AdGuard Home | Default Variables             #
+# Author(s):     sevos                                                   #
+# URL:           https://github.com/saltyorg/Community                   #
+# --                                                                     #
+##########################################################################
+#                   GNU General Public License v3.0                      #
+##########################################################################
+---
+################################
+# Basics
+################################
+
+adguardhome_name: adguardhome
+
+################################
+# Paths
+################################
+
+adguardhome_paths_folder: "{{ adguardhome_name }}"
+adguardhome_paths_location: "{{ server_appdata_path }}/{{ adguardhome_paths_folder }}"
+adguardhome_config_path: "{{ adguardhome_paths_location }}/conf/AdGuardHome.yaml"
+adguardhome_paths_folders_list:
+  - "{{ adguardhome_paths_location }}"
+  - "{{ adguardhome_paths_location }}/conf"
+  - "{{ adguardhome_paths_location }}/work"
+  - "{{ adguardhome_paths_location }}/work/data"
+  - "{{ adguardhome_paths_location }}/work/data/filters"
+
+################################
+# Web
+################################
+
+adguardhome_web_subdomain: "{{ adguardhome_name }}"
+adguardhome_web_domain: "{{ user.domain }}"
+adguardhome_web_port: "3000"
+adguardhome_web_url: "{{ 'https://' + adguardhome_web_subdomain + '.' + adguardhome_web_domain
+                   if (reverse_proxy_is_enabled)
+                   else 'http://localhost:' + adguardhome_web_port }}"
+
+################################
+# DNS
+################################
+
+adguardhome_dns_record: "{{ adguardhome_web_subdomain }}"
+adguardhome_dns_zone: "{{ adguardhome_web_domain }}"
+
+################################
+# Traefik
+################################
+
+adguardhome_traefik_sso_middleware: "{{ traefik_default_sso_middleware }}"
+adguardhome_traefik_middleware: "{{ traefik_default_middleware + ',' + adguardhome_traefik_sso_middleware
+                            if (adguardhome_traefik_sso_middleware | length > 0) 
+                            else traefik_default_middleware }}"
+adguardhome_traefik_certresolver: "{{ traefik_default_certresolver }}"
+adguardhome_traefik_enabled: true
+adguardhome_traefik_api_enabled: true
+adguardhome_traefik_api_endpoint: "`/dns-query`"
+
+################################
+# Docker
+################################
+
+# Container
+adguardhome_docker_container: "{{ adguardhome_name }}"
+
+# Image
+adguardhome_docker_image_pull: true
+adguardhome_docker_image_tag: "latest"
+adguardhome_docker_image: "adguard/adguardhome:{{ adguardhome_docker_image_tag }}"
+
+# Ports
+adguardhome_docker_ports_defaults:
+  - "{{ adguardhome_web_port }}"
+adguardhome_docker_ports_custom: []
+adguardhome_docker_ports: "{{ adguardhome_docker_ports_defaults
+                         + adguardhome_docker_ports_custom
+                      if (not reverse_proxy_is_enabled)
+                      else [] + adguardhome_docker_ports_custom }}"
+
+# Envs
+adguardhome_docker_envs_default:
+  PUID: "{{ uid }}"
+  PGID: "{{ gid }}"
+  TZ: "{{ tz }}"
+adguardhome_docker_envs_custom: {}
+adguardhome_docker_envs: "{{ adguardhome_docker_envs_default
+                        | combine(adguardhome_docker_envs_custom) }}"
+
+# Commands
+adguardhome_docker_commands_default: []
+adguardhome_docker_commands_custom: []
+adguardhome_docker_commands: "{{ adguardhome_docker_commands_default
+                            + adguardhome_docker_commands_custom }}"
+
+# Volumes
+adguardhome_docker_volumes_default:
+  - "{{ adguardhome_paths_location }}/work:/opt/adguardhome/work"
+  - "{{ adguardhome_paths_location }}/conf:/opt/adguardhome/conf"
+adguardhome_docker_volumes_custom: []
+bazarr_docker_volumes_theme: []
+adguardhome_docker_volumes: "{{ adguardhome_docker_volumes_default }}"
+
+# Devices
+adguardhome_docker_devices_default: []
+adguardhome_docker_devices_custom: []
+adguardhome_docker_devices: "{{ adguardhome_docker_devices_default
+                           + adguardhome_docker_devices_custom }}"
+
+# Hosts
+adguardhome_docker_hosts_default: []
+adguardhome_docker_hosts_custom: []
+adguardhome_docker_hosts: "{{ docker_hosts_common
+                         | combine(adguardhome_docker_hosts_default)
+                         | combine(adguardhome_docker_hosts_custom) }}"
+
+# Labels
+adguardhome_docker_labels_default: {}
+adguardhome_docker_labels_custom: {}
+adguardhome_docker_labels: "{{ docker_labels_common
+                          | combine(adguardhome_docker_labels_default)
+                          | combine(adguardhome_docker_labels_custom) }}"
+
+# Hostname
+adguardhome_docker_hostname: "{{ adguardhome_name }}"
+
+# Networks
+adguardhome_docker_networks_alias: "{{ adguardhome_name }}"
+adguardhome_docker_networks_default: []
+adguardhome_docker_networks_custom: []
+adguardhome_docker_networks: "{{ docker_networks_common
+                            + adguardhome_docker_networks_default
+                            + adguardhome_docker_networks_custom }}"
+
+# Capabilities
+adguardhome_docker_capabilities_default: []
+adguardhome_docker_capabilities_custom: []
+adguardhome_docker_capabilities: "{{ adguardhome_docker_capabilities_default
+                                + adguardhome_docker_capabilities_custom }}"
+
+# Security Opts
+adguardhome_docker_security_opts_default: []
+adguardhome_docker_security_opts_custom: []
+adguardhome_docker_security_opts: "{{ adguardhome_docker_security_opts_default
+                                 + adguardhome_docker_security_opts_custom }}"
+
+# Restart Policy
+adguardhome_docker_restart_policy: unless-stopped
+
+# State
+adguardhome_docker_state: started

--- a/roles/adguardhome/defaults/main.yml
+++ b/roles/adguardhome/defaults/main.yml
@@ -99,7 +99,6 @@ adguardhome_docker_volumes_default:
   - "{{ adguardhome_paths_location }}/work:/opt/adguardhome/work"
   - "{{ adguardhome_paths_location }}/conf:/opt/adguardhome/conf"
 adguardhome_docker_volumes_custom: []
-bazarr_docker_volumes_theme: []
 adguardhome_docker_volumes: "{{ adguardhome_docker_volumes_default }}"
 
 # Devices

--- a/roles/adguardhome/tasks/main.yml
+++ b/roles/adguardhome/tasks/main.yml
@@ -1,0 +1,48 @@
+#########################################################################
+# Title:            Community: AdGuard Home                             #
+# Author(s):        sevos                                               #
+# URL:              https://github.com/saltyorg/Community               #
+# --                                                                    #
+#########################################################################
+#                   GNU General Public License v3.0                     #
+#########################################################################
+---
+- name: Add DNS record
+  include_tasks: "{{ resources_tasks_path }}/dns/tasker.yml"
+  vars:
+    dns_record: "{{ lookup('vars', role_name + '_dns_record') }}"
+    dns_zone: "{{ lookup('vars', role_name + '_dns_zone') }}"
+
+- name: Remove existing Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/remove_docker_container.yml"
+
+- name: Create directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ user.name }}"
+    group: "{{ user.name }}"
+    mode: "0775"
+  with_items: "{{ lookup('vars', role_name + '_paths_folders_list') }}"
+
+- name: "Settings | Check if AdGuardHome.yaml exists"
+  stat:
+    path: "{{ adguardhome_config_path }}"
+  register: adguardhome_config
+
+- name: "Settings | New AdGuardHome.yaml tasks"
+  block:
+
+    - name: "Settings | Import AdGuardHome.yaml.js2"
+      template:
+        src: AdGuardHome.yaml.js2
+        dest: '{{ adguardhome_config_path }}'
+        owner: "{{ user.name }}"
+        group: "{{ user.name }}"
+        mode: 0775
+        force: yes
+
+  when: not adguardhome_config.stat.exists
+
+- name: Create Docker container
+  include_tasks: "{{ resources_tasks_path }}/docker/create_docker_container.yml"

--- a/roles/adguardhome/templates/AdGuardHome.yaml.js2
+++ b/roles/adguardhome/templates/AdGuardHome.yaml.js2
@@ -1,0 +1,125 @@
+bind_host: 0.0.0.0
+bind_port: 3000
+beta_bind_port: 0
+users: []
+auth_attempts: 5
+block_auth_min: 15
+http_proxy: ""
+language: ""
+rlimit_nofile: 0
+debug_pprof: false
+web_session_ttl: 720
+dns:
+  bind_hosts:
+  - 0.0.0.0
+  port: 53
+  statistics_interval: 1
+  querylog_enabled: true
+  querylog_file_enabled: true
+  querylog_interval: 90
+  querylog_size_memory: 1000
+  anonymize_client_ip: false
+  protection_enabled: true
+  blocking_mode: default
+  blocking_ipv4: ""
+  blocking_ipv6: ""
+  blocked_response_ttl: 10
+  parental_block_host: family-block.dns.adguard.com
+  safebrowsing_block_host: standard-block.dns.adguard.com
+  ratelimit: 20
+  ratelimit_whitelist: []
+  refuse_any: true
+  upstream_dns:
+  - https://dns10.quad9.net/dns-query
+  upstream_dns_file: ""
+  bootstrap_dns:
+  - 1.1.1.1
+  - 9.9.9.9
+  - 2606:4700:4700::1111
+  - 2620:fe::fe:9
+  all_servers: false
+  fastest_addr: false
+  allowed_clients: []
+  disallowed_clients: []
+  blocked_hosts:
+  - version.bind
+  - id.server
+  - hostname.bind
+  cache_size: 4194304
+  cache_ttl_min: 0
+  cache_ttl_max: 0
+  bogus_nxdomain: []
+  aaaa_disabled: false
+  enable_dnssec: true
+  edns_client_subnet: false
+  max_goroutines: 300
+  ipset: []
+  filtering_enabled: true
+  filters_update_interval: 24
+  parental_enabled: false
+  safesearch_enabled: false
+  safebrowsing_enabled: false
+  safebrowsing_cache_size: 1048576
+  safesearch_cache_size: 1048576
+  parental_cache_size: 1048576
+  cache_time: 30
+  rewrites: []
+  blocked_services: []
+  local_domain_name: lan
+  resolve_clients: true
+  local_ptr_upstreams: []
+tls:
+  enabled: true
+  server_name: {{ adguardhome_web_subdomain }}.{{ adguardhome_web_domain }}
+  force_https: false
+  port_https: 0
+  port_dns_over_tls: 0
+  port_dns_over_quic: 0
+  port_dnscrypt: 0
+  dnscrypt_config_file: ""
+  allow_unencrypted_doh: true
+  strict_sni_check: false
+  certificate_chain: ""
+  private_key: ""
+  certificate_path: ""
+  private_key_path: ""
+filters:
+- enabled: true
+  url: https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt
+  name: AdGuard DNS filter
+  id: 1
+- enabled: false
+  url: https://adaway.org/hosts.txt
+  name: AdAway Default Blocklist
+  id: 2
+- enabled: false
+  url: https://www.malwaredomainlist.com/hostslist/hosts.txt
+  name: MalwareDomainList.com Hosts List
+  id: 4
+whitelist_filters: []
+user_rules: []
+dhcp:
+  enabled: false
+  interface_name: ""
+  dhcpv4:
+    gateway_ip: ""
+    subnet_mask: ""
+    range_start: ""
+    range_end: ""
+    lease_duration: 86400
+    icmp_timeout_msec: 1000
+    options: []
+  dhcpv6:
+    range_start: ""
+    lease_duration: 86400
+    ra_slaac_only: false
+    ra_allow_slaac: false
+clients: []
+log_compress: false
+log_localtime: false
+log_max_backups: 0
+log_max_size: 100
+log_max_age: 3
+log_file: ""
+verbose: false
+schema_version: 10


### PR DESCRIPTION
# Description

[AdGuard Home](https://hub.docker.com/r/adguard/adguardhome) is a network-wide, open source software for blocking ads & tracking and for gaining control over all traffic in your home network. After you set it up, it'll cover ALL devices in your home Wi-Fi network, and you won't need any client-side software for that. At the same time, it provides a user-friendly web interface that allows you to easily manage the traffic, even from a mobile device.

# How Has This Been Tested?

I tested the role in wild and everything worked as expected.

# New Role Checklist:

- [✔️] <not ready yet> I have reviewed the [Contribute page in the wiki](https://docs.saltbox.dev/community/basics/#contributing-to-community-apps)
- [✔️] I have updated the header in any files I may have used as templates with my own information
- [✔️] I have added my new role to `community.yml`
- [✔️] I have verified that any Docker images used are current and supported.
- [✔️] I have made corresponding changes to the documentation or have submitted a separate PR to the docs repo for this purpose.
